### PR TITLE
Fix issue with current path

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,8 +2,8 @@
   "name": "select2-bootstrap-theme",
   "version": "0.1.0-beta.3",
   "main": [
-    "dist/select2-bootstrap.css",
-    "dist/select2-bootstrap.min.css"
+    "./dist/select2-bootstrap.css",
+    "./dist/select2-bootstrap.min.css"
   ],
   "ignore": [
     "**/.*",


### PR DESCRIPTION
Small fix to path of css files.

Issue with my version of bower (v1.4.1):
![bug](https://cloud.githubusercontent.com/assets/441774/7419695/384dc82a-ef4d-11e4-930d-e9453525b603.gif)

Inside folder `select2-bootstrap-theme` this create another folder with version `select2-bootstrap-theme-0.1.0-beta.3`.
