### PR TITLE
Don't highlight selected items

### DIFF
--- a/src/select2-bootstrap.less
+++ b/src/select2-bootstrap.less
@@ -180,7 +180,7 @@
          * Selected state.
          */
 
-        &--highlighted[aria-selected] {
+        &--highlighted[aria-selected=true] {
             background-color: @dropdown-link-active-bg;
             color: @dropdown-link-active-color;
         }

--- a/src/select2-bootstrap.scss
+++ b/src/select2-bootstrap.scss
@@ -180,7 +180,7 @@ $clear-selection-color: $dropdown-arrow-color !default;
          * Selected state.
          */
 
-        &--highlighted[aria-selected] {
+        &--highlighted[aria-selected=true] {
             background-color: $dropdown-link-active-bg;
             color: $dropdown-link-active-color;
         }


### PR DESCRIPTION
This makes the result list less confusing by always showing which elements are already selected
