### PR TITLE
Fix bug where math would not compile correctly in LESS version

### DIFF
--- a/src/select2-bootstrap.less
+++ b/src/select2-bootstrap.less
@@ -354,7 +354,7 @@
     .select2-selection--single {
         height: @input-height-base;
         line-height: @line-height-base;
-        padding: @padding-base-vertical @padding-base-horizontal + @caret-width-base*3 @padding-base-vertical @padding-base-horizontal;
+        padding: @padding-base-vertical (@padding-base-horizontal + @caret-width-base*3) @padding-base-vertical @padding-base-horizontal;
 
         /**
          * Adjust the single Select2's dropdown arrow button appearance.


### PR DESCRIPTION
Math in LESS won't be done unless it's surrounded by parenthesis. The result of compiling the LESS currently is something like "padding: 6px 12px + 4px*3 6px 6px". This fixes that issue.
