### PR TITLE
Remove deprecated bower option: version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "select2-bootstrap-theme",
-  "version": "0.1.0-beta.8",
   "main": [
     "src/build.scss",
     "src/build.less"


### PR DESCRIPTION
`version` option for `bower.json` it's deprecated and ignored by bower, as you can read in _`bower.json` specification_:

> https://github.com/bower/spec/blob/master/json.md#version
>   Use git or svn tags instead. This field is ignored by Bower.
